### PR TITLE
Allow all players with permission below Assistant GM to create alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [2.0.1] 2021-12-19
+
+- Fixed issue preventing all players with permission below `Assistant GM` to create alerts
+
 ## [2.0.0] 2021-06-11
 
 *Core 0.8 compatibility*

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "name": "turnAlert",
     "title": "Turn Alert",
     "description": "Set alerts to trigger on a particular round of combat or on a particular token's turn.",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "author": "Cole Schultz (cole#9640)",
     "languages": [
         {
@@ -43,8 +43,8 @@
     "compatibleCoreVersion": "0.8.6",
     "url": "https://github.com/schultzcole/FVTT-Turn-Alert",
     "manifest": "https://raw.githubusercontent.com/schultzcole/FVTT-Turn-Alert/master/module.json",
-    "download": "https://github.com/schultzcole/FVTT-Turn-Alert/archive/2.0.0.zip",
-    "license": "https://github.com/schultzcole/FVTT-Turn-Alert/blob/2.0.0/LICENSE",
-    "readme": "https://github.com/schultzcole/FVTT-Turn-Alert/blob/2.0.0/README.md",
-    "changelog": "https://github.com/schultzcole/FVTT-Turn-Alert/blob/2.0.0/CHANGELOG.md"
+    "download": "https://github.com/schultzcole/FVTT-Turn-Alert/archive/2.0.1.zip",
+    "license": "https://github.com/schultzcole/FVTT-Turn-Alert/blob/2.0.1/LICENSE",
+    "readme": "https://github.com/schultzcole/FVTT-Turn-Alert/blob/2.0.1/README.md",
+    "changelog": "https://github.com/schultzcole/FVTT-Turn-Alert/blob/2.0.1/CHANGELOG.md"
 }

--- a/module.json
+++ b/module.json
@@ -40,7 +40,7 @@
     ],
     "socket": true,
     "minimumCoreVersion": "0.8.5",
-    "compatibleCoreVersion": "0.8.6",
+    "compatibleCoreVersion": "0.8.9",
     "url": "https://github.com/schultzcole/FVTT-Turn-Alert",
     "manifest": "https://raw.githubusercontent.com/schultzcole/FVTT-Turn-Alert/master/module.json",
     "download": "https://github.com/schultzcole/FVTT-Turn-Alert/archive/2.0.1.zip",

--- a/scripts/TurnAlert.js
+++ b/scripts/TurnAlert.js
@@ -25,6 +25,10 @@ import { compareTurns } from "./utils.js";
  * }
  */
 
+function canUserModifyCombat() {
+    return game.user.isGM && game.user.active;
+}
+
 export default class TurnAlert {
     static get defaultData() {
         return {
@@ -277,7 +281,7 @@ export default class TurnAlert {
             );
         }
 
-        if (combat.canUserModify(game.user, "update")) {
+        if (canUserModifyCombat()) {
             const id = randomID(16);
             alertData.id = id;
 
@@ -324,7 +328,7 @@ export default class TurnAlert {
             );
         }
 
-        if (combat.canUserModify(game.user, "update")) {
+        if (canUserModifyCombat()) {
             if (data.repeating) {
                 data.repeating = foundry.utils.mergeObject(this.prototype.constructor.defaultRepeatingData, data.repeating);
             }
@@ -355,7 +359,7 @@ export default class TurnAlert {
             throw new Error(`The combat "${data.combatID}" does not exist.`);
         }
 
-        if (combat.canUserModify(game.user, "update")) {
+        if (canUserModifyCombat()) {
             const alerts = combat.getFlag(CONST.moduleName, "alerts") || {};
 
             if (!(alertId in alerts)) {


### PR DESCRIPTION
This commit fixes
`User "Name" lacks permission to update combat "combat_id"` errors when
any player without at least `Assistant GM` permission tries to create a
turn alert.

This is caused by `combat.canUserModify(game.user, "update")` returning
`true` for a player but `combat.setFlag` still failing.

The solution applied here is to rely on the socket system for non-GM
users to simply emit an event and let the GM user's client handle the
combat update. Of course, this won't work if there is no active GM
logged in.